### PR TITLE
Improve GitHub project presentation on portfolio

### DIFF
--- a/pages/proyectos.html
+++ b/pages/proyectos.html
@@ -32,11 +32,15 @@
                 <p>Feel free to explore and learn more about each one.</p>
             </div>
             <section class="navigation" id="proyectos">
+                <h3>Proyectos en GitHub</h3>
                 <ul class="project-list">
-                    <li>
-                        <a href="https://github.com/Nemog17/octave-blog">Octave Blog</a> &amp;
-                        <a href="https://github.com/Nemog17/octave-docker">Octave Docker</a>
-                        <p>He estado trabajando en este proyecto para una maestra de matemáticas de la Universidad PUCMM para que pueda impartir tareas y lecturas con ejercicios prácticos. Estos repositorios están conectados mediante Azure.</p>
+                    <li class="project-item">
+                        <h4><a href="https://github.com/Nemog17/octave-blog">Octave Blog</a></h4>
+                        <p>Proyecto para una maestra de matemáticas de la Universidad PUCMM que permite impartir tareas y lecturas con ejercicios prácticos. Se conecta con Octave Docker mediante Azure.</p>
+                    </li>
+                    <li class="project-item">
+                        <h4><a href="https://github.com/Nemog17/octave-docker">Octave Docker</a></h4>
+                        <p>Imagen Docker que acompaña al proyecto Octave Blog para ejecutar los ejercicios en la nube. Estos repositorios están conectados mediante Azure.</p>
                     </li>
                 </ul>
             </section>

--- a/src/css/proyectos.css
+++ b/src/css/proyectos.css
@@ -160,21 +160,34 @@ main {
     text-align: center; /* Center align title */
 }
 
+
 .navigation ul {
     list-style: none;
     padding: 0;
     margin: 0;
 }
 
-.navigation li {
-    margin-bottom: 1rem;
-    padding: 0.5rem;
-    border-radius: 5px;
-    transition: background-color 0.3s ease;
+.project-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1rem;
 }
 
-.navigation li:hover {
+.project-item {
+    margin-bottom: 1rem;
+    padding: 1rem;
+    border: 1px solid #333333;
+    border-radius: 5px;
+    transition: background-color 0.3s ease, transform 0.3s ease;
+}
+
+.project-item:hover {
     background-color: #333333;
+    transform: translateY(-5px);
+}
+
+.project-item h4 {
+    margin-bottom: 0.5rem;
 }
 
 .navigation a {


### PR DESCRIPTION
## Summary
- Separate GitHub projects into individual entries on the projects page
- Style project list as responsive cards for a cleaner portfolio layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d865a7948832186dd3a57bb95fbbb