### PR TITLE
feat: enlarge project cards

### DIFF
--- a/src/css/proyectos.css
+++ b/src/css/proyectos.css
@@ -149,7 +149,7 @@ main {
 }
 
 .navigation {
-    max-width: 600px;
+    max-width: 900px;
     text-align: left; /* Left-align for better readability */
 }
 
@@ -169,15 +169,16 @@ main {
 
 .project-list {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 1.5rem;
 }
 
 .project-item {
     margin-bottom: 1rem;
-    padding: 1rem;
+    padding: 1.5rem;
     border: 1px solid #333333;
-    border-radius: 5px;
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
     transition: background-color 0.3s ease, transform 0.3s ease;
     overflow: hidden;
 }
@@ -189,13 +190,19 @@ main {
 
 .project-item h4 {
     margin-bottom: 0.5rem;
+    font-size: 1.3rem;
+}
+
+.project-item p {
+    font-size: 1rem;
 }
 
 .project-image {
     width: 100%;
-    height: auto;
+    height: 200px;
+    object-fit: cover;
     border-radius: 4px;
-    margin-bottom: 0.5rem;
+    margin-bottom: 1rem;
     transition: transform 0.3s ease;
 }
 
@@ -283,5 +290,9 @@ footer a:hover {
 
     .navigation a {
         font-size: 1rem;
+    }
+
+    .project-image {
+        height: 150px;
     }
 }


### PR DESCRIPTION
## Summary
- expand project grid and navigation width for larger cards
- add padding, box-shadow, and larger images for clearer project display
- adjust mobile styles to keep images proportional on small screens

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d8c36e81c83219cb97e4dc32f65d1